### PR TITLE
Switch to docker-image-based deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,40 +1,42 @@
 #!/usr/bin/env groovy
 
 pipeline {
-
-    agent {
-        docker {
-            image 'node'
-            args '-u root'
-        }
-    }
+    agent any
 
     stages {
         stage('Build') {
             steps {
                 echo 'Building...'
-                sh 'npm install'
+
+                // Build the image.
+                script {
+                    image = docker.build("jftanner/flax")
+                }
             }
         }
+
         stage('Deploy') {
             when {
                 branch 'master'
             }
             steps {
                 script {
-                    transfers = [
-                            sshTransfer(remoteDirectory: 'flax', cleanRemote: true, sourceFiles: '**', execCommand: 'cd flax && docker-compose up --build -d')
-                    ]
+                    docker.withRegistry('https://registry.hub.docker.com', 'docker-hub-credentials') {
+                        image.push('latest')
+                    }
+                    sh 'ssh docker.tanndev.com rm -f flax-compose.yml'
+                    sh 'scp docker-compose.yml docker.tanndev.com:flax-compose.yml'
+                    sh 'ssh docker.tanndev.com docker-compose -f flax-compose.yml pull app'
+                    sh 'ssh docker.tanndev.com docker-compose -f flax-compose.yml up -d'
                 }
-                sshPublisher(failOnError: true, publishers: [sshPublisherDesc(configName: 'Tanndev Docker', transfers: transfers)])
-                slackSend channel: '#flax', color: 'good', message: 'Successfully built <https://flax.tanndev.com|Flax website>.'
+                slackSend channel: '#flax', color: 'good', message: 'Successfully published <https://maelstrom.tanndev.com|Flax Website>.'
             }
         }
     }
 
     post {
         failure {
-            slackSend channel: '#flax', color: 'danger', message: "Failed to build Flax website. (<${env.JOB_URL}|Pipeline>) (<${env.BUILD_URL}console|Console>)"
+            slackSend channel: '#flax', color: 'danger', message: "Failed to build/publish Flax Website. (<${env.JOB_URL}|Pipeline>) (<${env.BUILD_URL}console|Console>)"
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
   app:
-    build: .
-    container_name: devon-game
+    image: jftanner/flax
+    container_name: flax
     ports:
     - 8081:8081
     environment:


### PR DESCRIPTION
This PR changes how the app is published by creating a docker image, publishing it to docker hub, and then executing it docker-compose via SSH.