### PR TITLE
Update build agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,7 @@
 
 pipeline {
     agent {
-        dockerfile {
-            filename 'Dockerfile.jenkins-agent'
-            args '-v /var/run/docker.sock:/var/run/docker.sock -v /etc/passwd:/etc/passwd -v /var/lib/jenkins:/var/lib/jenkins'
-        }
+        label 'nodejs && docker'
     }
 
     stages {


### PR DESCRIPTION
This switches from a docker-based agent running on the master to a proper stand-alone container. This should hopefully prevent issues with file permissions getting corrupted, etc.